### PR TITLE
디자인에 맞춰 컬러 팔레트 및 폰트 정의 추가

### DIFF
--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -1,0 +1,16 @@
+const colors = {
+  primary: "#2F4CDD", // Primary
+  secondary: "#DEE4FF", // Secondary
+  accent: "#B519EC", // Accent
+  textPrimary: "#000000", // Text Primary
+  textSecondary: "#0F0F0F", // Text Secondary
+  textMuted: "#3E4954", // Text Muted
+  backgroundLight: "#F5F6FA", // Background Light
+  success: "#28C76F", // Success
+  danger: "#EA5455", // Danger
+  warning: "#FF9F43", // Warning
+  darkBackground: "#2C2E33", // Dark Background
+  brightOrange: "#FF6F61", // Bright Orange
+};
+
+export default colors;

--- a/src/styles/font.ts
+++ b/src/styles/font.ts
@@ -1,0 +1,48 @@
+const fonts = {
+  "40_600": {
+    fontSize: "40px",
+    fontWeight: 600,
+  },
+  "36_800": {
+    fontSize: "36px",
+    fontWeight: 800,
+  },
+  "32_600": {
+    fontSize: "32px",
+    fontWeight: 600,
+  },
+  "28_600": {
+    fontSize: "28px",
+    fontWeight: 600,
+  },
+  "20_500": {
+    fontSize: "20px",
+    fontWeight: 500,
+  },
+  "18_600": {
+    fontSize: "18px",
+    fontWeight: 600,
+  },
+  "18_400": {
+    fontSize: "18px",
+    fontWeight: 400,
+  },
+  "16_500": {
+    fontSize: "16px",
+    fontWeight: 500,
+  },
+  "16_400": {
+    fontSize: "16px",
+    fontWeight: 400,
+  },
+  "14_500": {
+    fontSize: "14px",
+    fontWeight: 500,
+  },
+  "12_400": {
+    fontSize: "12px",
+    fontWeight: 400,
+  },
+};
+
+export default fonts;


### PR DESCRIPTION
## 관련 이슈

- 이슈 번호: #3 

## 변경 사항

- 디자인에 맞춰 컬러 팔레트 및 폰트 정의 추가
- 사용법

<img width="393" alt="스크린샷 2024-08-24 오후 2 39 04" src="https://github.com/user-attachments/assets/9c786607-ca25-4da1-839b-e2e0d5b7f4c6">

```js
const _container = [
  css`
    width: 100%;
    height: 500px;
    display: flex;
    align-items: center;
    justify-content: center;
    color: ${colors.accent};
  `,
  fonts["32_600"],
];

```

## 코드 리뷰 시 주의 사항

- 추후에 태블릿 반응형시 폰트 크기 수정이 필요할 경우(필요없을것 같지만) rem으로 단위 변경을 고려해야할 것 같아요

## 기타 사항

- 혹시 더 괜찮은 방법 있으시면 알려주세요. themeProvider까지 쓸 규모는 아니라고 판단해서 사용은 안했습니다.

Closes #3 
