### PR TITLE
Input 컴포넌트를 구현합니다.

### DIFF
--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -1,0 +1,16 @@
+import Input from "./Input";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Input> = {
+  title: "ui/Input",
+  component: Input,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const InputStory: Story = {
+  name: "Input",
+  args: {},
+};

--- a/src/components/common/Input/Input.styled.ts
+++ b/src/components/common/Input/Input.styled.ts
@@ -1,0 +1,33 @@
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+
+import colors from "styles/color";
+
+import type { InputProps } from "./Input.types";
+
+export const Container = styled.div<InputProps>`
+  position: relative;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 10px;
+  background-color: ${colors.white};
+  border: 1px solid #e5e5e5;
+
+  ${({ isError }) =>
+    isError &&
+    css`
+      border: 1px solid ${colors.danger};
+    `};
+
+  &::placeholder {
+    color: ${colors.secondary};
+  }
+`;
+
+export const Input = styled.input`
+  height: 100%;
+  padding: 10px 16px;
+  flex: 1;
+`;

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,0 +1,28 @@
+/** @jsxImportSource @emotion/react */
+import { forwardRef } from "react";
+import { css } from "@emotion/react";
+
+import * as S from "./Input.styled";
+import type { InputProps } from "./Input.types";
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, isError, prefix, suffix, ...restProps }, ref) => {
+    return (
+      <S.Container className={className} isError={isError}>
+        {prefix && <span css={_prefix}>{prefix}</span>}
+        <S.Input ref={ref} prefix={prefix} {...restProps} />
+        {suffix && <span css={_suffix}>{suffix}</span>}
+      </S.Container>
+    );
+  }
+);
+
+const _prefix = css`
+  padding-left: 12px;
+`;
+
+const _suffix = css`
+  padding-right: 12px;
+`;
+
+export default Input;

--- a/src/components/common/Input/Input.types.ts
+++ b/src/components/common/Input/Input.types.ts
@@ -1,0 +1,7 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
+export type InputProps = {
+  prefix?: ReactNode;
+  suffix?: ReactNode;
+  isError?: boolean;
+} & ComponentPropsWithoutRef<"input">;

--- a/src/components/common/Input/index.ts
+++ b/src/components/common/Input/index.ts
@@ -1,0 +1,1 @@
+export { default as Input } from './Input';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,1 +1,2 @@
 export * from "./Button";
+export * from "./Input";

--- a/src/pages/Component.tsx
+++ b/src/pages/Component.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 
-import { Button } from "components";
+import { Button, Input } from "components";
 
 export default function Component() {
   return (
@@ -9,10 +9,25 @@ export default function Component() {
       <Button css={[_button]} backgroundColor="accent">
         123
       </Button>
+
+      <div css={_spacing} />
+
+      <Input css={_input} />
+      <Input css={_input} prefix="단위" />
+      <Input css={_input} suffix="원" />
+      <Input css={_input} isError />
     </div>
   );
 }
 
 const _button = css`
   width: 120px;
+`;
+
+const _input = css`
+  width: 318px;
+`;
+
+const _spacing = css`
+  height: 64px;
 `;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -98,3 +98,10 @@ td {
   text-align: left;
   border-bottom: 1px solid #ddd;
 }
+
+input {
+  border: none;
+  outline: none;
+  /* FIXME: 스타일이 올바르게 보이기 위해서 임시로 해당 스타일을 적용합니다. @Seung-wan */
+  border-radius: 12px;
+}


### PR DESCRIPTION
## 관련 이슈

- 이슈 번호: #13 

## 변경 사항

- 설명
  - base 브랜치가 main이 아닌 feature/common-components(Button 컴포넌트 구현한 브랜치)입니다!
  - common/Input 폴더 아래에 Input 컴포넌트와 관련된 코드를 작성합니다.
  - 컴포넌트, 타입, 스타일, 스토리, export등 각각의 역할마다 별도의 파일을 두었습니다.
  - prefix, suffix props로 input의 앞, 뒤에 텍스트나 아이콘등을 추가할 수 있도록 하였습니다.
  - 해당 컴포넌트를 사용할 때 추가적인 스타일링이 필요한 경우에는 외부에서 css 속성으로 스타일을 주입할 수 있습니다.


## 코드 리뷰 시 주의 사항

- 설명: 코드 리뷰 시 집중적으로 봐줬으면 하는 부분이나 논의가 필요한 사항에 대해 설명해주세요.
  - Input 컴포넌트의 Props로 추가적으로 받으면 좋을만한 요소들을 제안주시면 좋을 것 같습니다!
  
## 테스트 방법

- npm run dev 명령어로 서버를 띄운 후에 [여기](http://localhost:5173/components)에서 인풋 컴포넌트를 확인해주세요.
