### PR TITLE
주문 디테일 페이지 구현

### DIFF
--- a/src/api/modules/order/index.ts
+++ b/src/api/modules/order/index.ts
@@ -1,7 +1,12 @@
 import axiosInstance from 'api/core';
 
 import type { CommonResponseReturnType } from '../commonType';
-import type { GetOrdersParams, GetOrdersResponse } from './types';
+import type {
+  GetOrderParams,
+  GetOrderResponse,
+  GetOrdersParams,
+  GetOrdersResponse,
+} from './types';
 
 const URL_ROOT = '/stores';
 
@@ -13,6 +18,17 @@ export const orderApi = {
     const { data } = await axiosInstance.get(`${URL_ROOT}/${storeId}/orders`, {
       params,
     });
+
+    return data;
+  },
+
+  getOrder: async ({
+    storeId,
+    orderId,
+  }: GetOrderParams): Promise<CommonResponseReturnType<GetOrderResponse>> => {
+    const { data } = await axiosInstance.get(
+      `${URL_ROOT}/${storeId}/orders/${orderId}`
+    );
 
     return data;
   },

--- a/src/api/modules/order/types.ts
+++ b/src/api/modules/order/types.ts
@@ -13,6 +13,11 @@ export type GetOrdersResponse = {
   totalCount: number;
 };
 
+export type GetOrderParams = {
+  storeId: number;
+  orderId: number;
+};
+
 type Order = {
   orderId: number;
   status: string;
@@ -20,3 +25,41 @@ type Order = {
   ordererName: string;
   menuTotalPrice: number;
 };
+
+export type GetOrderResponse = {
+  orderId: number;
+  status: string;
+  price: number;
+  orderTime: string;
+  store: Store;
+  orderer: Orderer;
+  menus: Menu[];
+};
+
+interface Menu {
+  name: string;
+  price: number;
+  quantity: number;
+  options: Option[];
+}
+
+interface Option {
+  seq: number;
+  name: string;
+  value: string;
+  price: number;
+}
+
+interface Orderer {
+  userId: string;
+  name: string;
+  phone: string;
+  address: string;
+  addressDetail: string;
+  zipCode: string;
+}
+
+interface Store {
+  storeId: number;
+  name: string;
+}

--- a/src/mocks/__fixtures__/orders.ts
+++ b/src/mocks/__fixtures__/orders.ts
@@ -489,7 +489,7 @@ export const orderMockData = {
   detail: {
     response: {
       orderId: 1,
-      status: '주문 상태',
+      status: 'CANCEL',
       price: 11000,
       orderTime: '2024-08-20 10:00:00',
       store: {
@@ -497,16 +497,16 @@ export const orderMockData = {
         name: '가게 상호명',
       },
       orderer: {
-        userId: '사용자 id',
-        name: '주문자 이름',
-        phone: '주문자 휴대폰 번호',
-        address: '배달 주소',
-        addressDetail: '상세 주소',
-        zipCode: '355-14',
+        userId: '1',
+        name: '유승완',
+        phone: '01012341234',
+        address: '서울특별시 중랑구 신내역로 1길 85',
+        addressDetail: '101동 1002호',
+        zipCode: '02055',
       },
       menus: [
         {
-          name: '메뉴명',
+          name: '삼성짜장',
           price: 10000,
           quantity: 1,
           options: [

--- a/src/pages/order/index.tsx
+++ b/src/pages/order/index.tsx
@@ -148,6 +148,10 @@ const Order = ({ ...rest }) => {
     );
   };
 
+  const gotoOrderDetail = (id: number) => {
+    navigate(`${storeId}/order/${id}`);
+  };
+
   if (!orders) {
     return null;
   }
@@ -197,7 +201,16 @@ const Order = ({ ...rest }) => {
           </thead>
           <tbody>
             {table.getRowModel().rows.map((row) => (
-              <tr key={row.id}>
+              <tr
+                css={css`
+                  cursor: pointer;
+                  &:hover {
+                    background-color: ${colors.secondary};
+                  }
+                `}
+                key={row.id}
+                onClick={() => gotoOrderDetail(row.original.orderId)}
+              >
                 {row.getVisibleCells().map((cell) => (
                   <td
                     key={cell.id}

--- a/src/pages/order/index.tsx
+++ b/src/pages/order/index.tsx
@@ -15,7 +15,7 @@ import { Filter } from 'common/components';
 import { Lightning } from 'common/components/icons';
 import { Pagination } from 'common/components/pagination';
 import { format } from 'date-fns';
-import { useGetOrdersQuery } from 'queries/modules/order/useOrderQuery';
+import { useGetOrdersQuery } from 'queries/modules/order/useGetOrdersQuery';
 import { ChangeEvent, useMemo } from 'react';
 import {
   useLocation,
@@ -149,7 +149,7 @@ const Order = ({ ...rest }) => {
   };
 
   const gotoOrderDetail = (id: number) => {
-    navigate(`${storeId}/order/${id}`);
+    navigate(`/${storeId}/order/${id}`);
   };
 
   if (!orders) {

--- a/src/pages/order/index.tsx
+++ b/src/pages/order/index.tsx
@@ -187,7 +187,13 @@ const Order = ({ ...rest }) => {
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <th key={header.id} colSpan={header.colSpan}>
+                  <th
+                    css={css`
+                      padding: 20px;
+                    `}
+                    key={header.id}
+                    colSpan={header.colSpan}
+                  >
                     <div>
                       {flexRender(
                         header.column.columnDef.header,

--- a/src/pages/orderDetail/index.tsx
+++ b/src/pages/orderDetail/index.tsx
@@ -1,13 +1,129 @@
 /** @jsxImportSource @emotion/react */
-import { css } from "@emotion/react";
-import { useParams } from "react-router-dom";
+import { css } from '@emotion/react';
+import { useGetOrderQuery } from 'queries/modules/order/useGetOrderDetailQuery';
+import { useParams } from 'react-router-dom';
+import colors from 'styles/color';
+import { commaize } from 'utils/commaize';
 
-const OrderDetail = ({ ...rest }) => {
-  const { id } = useParams();
-  console.log(id);
-  return <div css={[_container]} {...rest}></div>;
+const OrderDetail = () => {
+  const { storeId, orderId } = useParams() as {
+    storeId: string;
+    orderId: string;
+  };
+
+  const { data: order } = useGetOrderQuery({
+    storeId: Number(storeId),
+    orderId: Number(orderId),
+  });
+
+  console.log('order =', order);
+
+  if (!order) {
+    return null;
+  }
+
+  const { orderId: apiOrderId, price, menus, orderer, status } = order.response;
+
+  return (
+    <div css={[_container]}>
+      <div
+        css={css`
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          font-size: 28px;
+          font-weight: 600;
+        `}
+      >
+        <div>
+          주문번호: #{apiOrderId} / {commaize(price)}원
+        </div>
+        {/* TODO: 서버의 enum 확인후에 label과 매핑해주는 객체 이용해서 수정 */}
+        <div>{status}</div>
+      </div>
+      <div
+        css={css`
+          display: flex;
+          gap: 40px;
+          margin-top: 36px;
+        `}
+      >
+        <div
+          css={css`
+            display: flex;
+            flex-direction: column;
+            padding: 16px;
+            width: 340px;
+            border-radius: 20px;
+            background-color: ${colors.white};
+          `}
+        >
+          <div
+            css={css`
+              font-size: 20px;
+              font-weight: 600;
+            `}
+          >
+            주문자 정보
+          </div>
+          <div
+            css={css`
+              margin-top: 8px;
+            `}
+          >
+            주문자 이름 : {orderer.name}
+          </div>
+          <div>주문자 전화번호 : {orderer.phone}</div>
+          <div>배달 주소: {orderer.address}</div>
+          <div>상세 주소: {orderer.addressDetail}</div>
+          <div>우편번호: {orderer.zipCode}</div>
+        </div>
+        <div
+          css={css`
+            flex: 1;
+            border-radius: 20px;
+            background-color: ${colors.white};
+            padding: 16px;
+          `}
+        >
+          <div
+            css={css`
+              display: flex;
+              justify-content: space-between;
+              padding: 8px 0;
+              border-bottom: 1px solid ${colors.gray};
+              font-size: 20px;
+              font-weight: 600;
+            `}
+          >
+            <div>메뉴</div>
+            <div>수량</div>
+            <div>가격</div>
+            <div>총 가격</div>
+          </div>
+          {menus.map(({ name, price, quantity }, index) => (
+            <div
+              key={index}
+              css={css`
+                display: flex;
+                justify-content: space-between;
+                margin-top: 16px;
+              `}
+            >
+              <div>{name}</div>
+              <div>{quantity}</div>
+              <div>{commaize(price)}원</div>
+              <div>{commaize(price * quantity)}원</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default OrderDetail;
 
-const _container = css``;
+const _container = css`
+  padding: 40px 48px 92px;
+`;

--- a/src/queries/keys/index.ts
+++ b/src/queries/keys/index.ts
@@ -54,6 +54,7 @@ const queryKeys = {
       'list',
       params,
     ],
+    detail: ['order', 'detail'],
   },
 };
 

--- a/src/queries/modules/order/useGetOrderDetailQuery.ts
+++ b/src/queries/modules/order/useGetOrderDetailQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { orderApi } from 'api/modules/order';
+import type { GetOrderParams } from 'api/modules/order/types';
+
+import queryKeys from 'queries/keys';
+
+export const useGetOrderQuery = (params: GetOrderParams) => {
+  const query = useQuery({
+    queryKey: queryKeys.order.detail,
+    queryFn: () => {
+      return orderApi.getOrder(params);
+    },
+  });
+
+  return query;
+};

--- a/src/queries/modules/order/useGetOrdersQuery.ts
+++ b/src/queries/modules/order/useGetOrdersQuery.ts
@@ -5,7 +5,6 @@ import type { GetOrdersParams } from 'api/modules/order/types';
 
 import queryKeys from 'queries/keys';
 
-// 프로필 조회 쿼리 훅
 export const useGetOrdersQuery = (
   storeId: number,
   queryParams?: GetOrdersParams,

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -12,6 +12,7 @@ const colors = {
   warning: '#FF9F43', // Warning
   darkBackground: '#2C2E33', // Dark Background
   brightOrange: '#FF6F61', // Bright Orange
+  brightRed: '#FF6D4D',
   white: '#fff', // White
   lightWhite: '#fdfdfd',
   mildWhite: '#f9f9f9',


### PR DESCRIPTION
## 관련 이슈

- 이슈 번호: #35 

## 변경 사항

- 설명: 주문 목록 페이지에서 주문을 클릭하게 되면 주문 목록 디테일 페이지로 이동하게 됩니다.
  - 디자인 시안에서 주문 상태나 배달 기사에 관련된 UI는 구현하지 않았습니다.
  - 주문자 정보와 메뉴 정보만 간략하게 구현했습니다.

## 코드 리뷰 시 주의 사항

- 설명: 코드 리뷰 시 집중적으로 봐줬으면 하는 부분이나 논의가 필요한 사항에 대해 설명해주세요.
  - 예: `http://localhost:5173/1/order/1`에서 확인해주세요.

## 기타 사항

- 기타 코멘트나 필요한 정보가 있다면 추가해주세요.
