### PR TITLE
메뉴상세에서 menu preview를 위한 모달 추가

### DIFF
--- a/src/pages/menu/components/menuPreviewModal/index.tsx
+++ b/src/pages/menu/components/menuPreviewModal/index.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { MenuPreviewModalProps } from './index.types';
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ModalContent = styled.div`
+  background: #f5f5f5;
+  border-radius: 16px;
+  width: 90%;
+  max-width: 420px;
+  padding: 36px;
+`;
+
+const MenuImageWrap = styled.div`
+  width: 100%;
+  height: 200px;
+  background: #c4c4c4;
+  border-radius: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+  font-size: 16px;
+  overflow: hidden;
+`;
+
+const MenuImage = styled.img`
+  width: 100%;
+`;
+
+const MenuTitle = styled.h2`
+  margin: 16px 0;
+  font-size: 24px;
+`;
+
+const MenuDescription = styled.p`
+  color: #666;
+  font-size: 14px;
+  line-height: 1.5;
+`;
+
+const OptionSection = styled.div`
+  margin: 16px 0;
+`;
+
+const OptionTitle = styled.div`
+  margin-bottom: 8px;
+  font-size: 16px;
+`;
+
+const OptionItem = styled.label`
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+`;
+
+const OptionCheckbox = styled.input`
+  margin-right: 8px;
+`;
+
+const Price = styled.span`
+  margin-left: auto;
+`;
+
+const CloseButton = styled.button`
+  width: 100%;
+  background: #6779ff;
+  color: #fff;
+  border: none;
+  padding: 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 16px;
+  margin-top: 16px;
+`;
+
+const MenuPreviewModal: React.FC<MenuPreviewModalProps> = ({
+  onClose,
+  menuImage,
+  menuTitle,
+  menuDescription,
+  optionSections,
+}) => {
+  return (
+    <ModalOverlay>
+      <ModalContent>
+        <MenuImageWrap>
+          <MenuImage src={menuImage} alt={`preview_${menuTitle}`} />
+        </MenuImageWrap>
+        <MenuTitle>{menuTitle}</MenuTitle>
+        <MenuDescription>{menuDescription}</MenuDescription>
+
+        {optionSections.map((section, sectionIndex) => (
+          <OptionSection key={sectionIndex}>
+            <OptionTitle>
+              {section.title} ({section.requirement} - {section.type})
+            </OptionTitle>
+            {section.options.map((option, index) => (
+              <OptionItem key={index}>
+                <OptionCheckbox
+                  type="checkbox"
+                  defaultChecked={option.checked}
+                  disabled={section.type === '단일'}
+                />{' '}
+                {option.name} <Price>+ ₩{option.price}</Price>
+              </OptionItem>
+            ))}
+          </OptionSection>
+        ))}
+
+        <CloseButton onClick={onClose}>닫기</CloseButton>
+      </ModalContent>
+    </ModalOverlay>
+  );
+};
+
+export default MenuPreviewModal;

--- a/src/pages/menu/components/menuPreviewModal/index.types.ts
+++ b/src/pages/menu/components/menuPreviewModal/index.types.ts
@@ -1,0 +1,20 @@
+type Option = {
+  name: string;
+  price: number;
+  checked?: boolean;
+};
+
+type OptionSectionData = {
+  title: string;
+  requirement: string;
+  type: string;
+  options: Option[];
+};
+
+export type MenuPreviewModalProps = {
+  onClose: () => void;
+  menuImage: string;
+  menuTitle: string;
+  menuDescription: string;
+  optionSections: OptionSectionData[];
+};

--- a/src/pages/menu/detail.tsx
+++ b/src/pages/menu/detail.tsx
@@ -17,11 +17,13 @@ import type {
 } from 'api/modules/stores/types';
 import useMenuDetail from './hooks/useMenuDetail';
 import useMenuOption from './hooks/useMenuOption';
+import MenuPreviewModal from './components/menuPreviewModal';
 
 //TODO status 뭐로 추가하지?
 const MenuDetail = ({ data }: { data: MenuDetailInfo }) => {
   const { options } = data;
   const [isOptionModalOpen, setIsOptionModalOpen] = useState<boolean>(false);
+  const [isPreviewModalOpen, setIsPreviewModalOpen] = useState<boolean>(false);
   const [selectedOptionToEdit, setSelectedOptionToEdit] = useState<{
     data: CreateMenuOptionGroupReq;
     index: number;
@@ -41,12 +43,29 @@ const MenuDetail = ({ data }: { data: MenuDetailInfo }) => {
   const handleCloseEditModal = () => setSelectedOptionToEdit(null);
   const handleOptionModalOpen = () => setIsOptionModalOpen((prev) => !prev);
 
+  const menuPreviewModel = {
+    menuImage: imageMetadata ? imageMetadata.src : originalImage,
+    menuTitle: data.name,
+    menuDescription: data.desc,
+    optionSections: data.options.map((optionGroup) => ({
+      title: optionGroup.title,
+      requirement: optionGroup.isRequired ? '필수' : '선택',
+      type: optionGroup.isMultiple ? '다중' : '단일',
+      options: optionGroup.details.map((detail) => ({
+        name: detail.name,
+        price: detail.price,
+        checked: false, // 기본값으로 false 설정
+      })),
+    })),
+  };
   return (
     <>
       <div css={[_container]}>
         <div css={_titleWrap}>
           <h2>Menu</h2>
-          <button css={_subButton}>미리보기</button>
+          <button css={_subButton} onClick={() => setIsPreviewModalOpen(true)}>
+            미리보기
+          </button>
         </div>
         <section css={_menuContainer}>
           <h3 css={_subtitle}>기본 정보</h3>
@@ -130,6 +149,12 @@ const MenuDetail = ({ data }: { data: MenuDetailInfo }) => {
               ...optionGroup,
             });
           }}
+        />
+      )}
+      {isPreviewModalOpen && (
+        <MenuPreviewModal
+          onClose={() => setIsPreviewModalOpen(false)}
+          {...menuPreviewModel}
         />
       )}
     </>


### PR DESCRIPTION
## 관련 이슈

- 이슈 번호: x

## 변경 사항

- 설명: 메뉴 상세에서 미리보기 버튼 클릭시 프로덕트 모바일에서 보이는 preview 화면 구현
<img width="1302" alt="스크린샷 2024-10-31 오후 9 36 43" src="https://github.com/user-attachments/assets/218a7019-40b4-47a2-96cd-55cd51a6a6e5">

## 코드 리뷰 시 주의 사항

- 설명: x

## 기타 사항

- 기타 코멘트나 필요한 정보가 있다면 추가해주세요.
